### PR TITLE
Removed .env, added .env.example, added MONGO_DB to .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,5 @@ instance/
 # VSCode
 .vscode
 
-
-#TODO add .env to your gitignore
-
+# .env
+.env

--- a/server/.env
+++ b/server/.env
@@ -1,3 +1,0 @@
-TEAM_NAME="team-phoenix,Simerpreet Jassal"
-TEAM_LEAD="Sina  Jamshidi"
-FLASK_ENV="development"

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,8 @@
+# Save a copy of this file as .env and fill in the mongo connection string
+
+TEAM_NAME="team-phoenix,Simerpreet Jassal"
+TEAM_LEAD="Sina  Jamshidi"
+FLASK_ENV="development"
+
+# Put your mongo_db connection string in here
+MONGO_DB=""


### PR DESCRIPTION
The .env file needs to hold secrets such as the mongodb password. I've removed it from the repo and added an example env file instead. Everyone will need to add the example line to their .env file in order to run the server once we hook it up to the database.